### PR TITLE
feat: bump release level to ga

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
   "client_documentation": "https://googleapis.dev/python/cloudasset/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
-  "release_level": "beta",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-asset",
   "distribution_name": "google-cloud-asset",

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,15 @@
 Python Client for Cloud Asset API
 =================================
 
-|beta| |pypi| |versions| 
+|ga| |pypi| |versions|
 
 `Cloud Asset API`_: The cloud asset API manages the history and inventory of cloud resources.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+.. |ga| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg
    :target: https://pypi.org/project/google-cloud-asset/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-asset.svg

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ version = "0.7.0"
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
-release_status = "Development Status :: 4 - Beta"
+release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',


### PR DESCRIPTION
Release-As: 1.0.0

The underlying API is GA and this library has satisfied the required bake time.

[GA release template](https://github.com/googleapis/google-cloud-common/issues/287)
## Required 

- [x] 28 days elapsed since last beta release with new API surface
- [x] Server API is GA
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA
