### PR TITLE
Update README.rst: WIn instuctions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,10 +73,9 @@ Windows
 
 .. code-block:: console
 
-    pip install virtualenv
-    virtualenv <your-env>
+    py -3.9 -m venv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install google-cloud-asset
+    python -m pip install google-cloud-asset
 
 Next Steps
 ~~~~~~~~~~


### PR DESCRIPTION
A more bulletproof way on windows.

`pip install x` is the road to confusions. Python's way on windows to manage multiple versions is to use py -<version> to target your version.

Then once venv created and activated, a python.exe becomes available which you can call with `python ...`.

The `python -m pip ...` was recently used inside Python's source code. This was also illustrated by Brett Cannnon's article" [Why you should use `python -m pip`](https://snarky.ca/why-you-should-use-python-m-pip/)
