### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudasset",
     "name_pretty": "Cloud Asset Inventory",
     "product_documentation": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-    "client_documentation": "https://googleapis.dev/python/cloudasset/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudasset/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.