### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudasset",
     "name_pretty": "Cloud Asset Inventory",
     "product_documentation": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-    "client_documentation": "https://googleapis.dev/python/cloudasset/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudasset/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Asset API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-asset.svg
    :target: https://pypi.org/project/google-cloud-asset/
 .. _Cloud Asset API: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/reference/rest/
-.. _Client Library Documentation: https://googleapis.dev/python/cloudasset/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudasset/latest
 .. _Product Documentation:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.