### PR TITLE
fix: Use unittest.mock if available

### DIFF
--- a/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/unit/gapic/asset_v1p1beta1/test_asset_service.py
+++ b/tests/unit/gapic/asset_v1p1beta1/test_asset_service.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/unit/gapic/asset_v1p2beta1/test_asset_service.py
+++ b/tests/unit/gapic/asset_v1p2beta1/test_asset_service.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/unit/gapic/asset_v1p4beta1/test_asset_service.py
+++ b/tests/unit/gapic/asset_v1p4beta1/test_asset_service.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/unit/gapic/asset_v1p5beta1/test_asset_service.py
+++ b/tests/unit/gapic/asset_v1p5beta1/test_asset_service.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio


### PR DESCRIPTION
The `mock` module is deprecated in recent Python releases, so try to
import the standard `unittest.mock` library if it is available.

Signed-off-by: Major Hayden <major@mhtx.net>

Fixes #427 🦕
